### PR TITLE
Fix typo

### DIFF
--- a/LvglComponent.h
+++ b/LvglComponent.h
@@ -3,7 +3,7 @@
 #include "esphome.h"
 #include "lvgl.h"
 #include "lv_demo.h"
-#include "tft_espi.h"
+#include "TFT_eSPI.h"
 #include "bootlogo.h"
 
 const size_t buf_pix_count = LV_HOR_RES_MAX * LV_VER_RES_MAX / 5;


### PR DESCRIPTION
It fails to build on raspberry pi:
```
In file included from src/main.cpp:22:0:
src/LvglComponent.h:6:22: fatal error: tft_espi.h: No such file or directory
```
